### PR TITLE
Event update

### DIFF
--- a/abis/BloomPool.ts
+++ b/abis/BloomPool.ts
@@ -635,6 +635,38 @@ export const bloomPoolAbi = [
     type: 'event',
     anonymous: false,
     inputs: [
+      { name: 'id', internalType: 'uint256', type: 'uint256', indexed: true },
+      {
+        name: 'account',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'borrower',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'amount',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+      {
+        name: 'borrowerCollateral',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'MatchOrderConverted',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
       {
         name: 'account',
         internalType: 'address',

--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -379,7 +379,7 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
                 _borrowerAmounts[matches[index].borrower][id] += borrowerFunds;
                 borrowerAmountConverted += borrowerFunds;
 
-                emit MatchOrderKilled(account, matches[index].borrower, amountToRemove);
+                emit MatchOrderConverted(id, account, matches[index].borrower, amountToRemove, borrowerFunds);
 
                 if (lenderFunds == matches[index].lCollateral) {
                     matches.pop();

--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -379,7 +379,7 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
                 _borrowerAmounts[matches[index].borrower][id] += borrowerFunds;
                 borrowerAmountConverted += borrowerFunds;
 
-                emit MatchOrderConverted(id, account, matches[index].borrower, amountToRemove, borrowerFunds);
+                emit MatchOrderConverted(id, account, matches[index].borrower, lenderFunds, borrowerFunds);
 
                 if (lenderFunds == matches[index].lCollateral) {
                     matches.pop();

--- a/src/interfaces/IBloomPool.sol
+++ b/src/interfaces/IBloomPool.sol
@@ -63,7 +63,13 @@ interface IBloomPool is IOrderbook, IPoolStorage {
      * @param lenderCollateral The amount of lender collateral converted.
      * @param borrowerCollateral The amount of borrower collateral converted.
      */
-    event MatchOrderConverted(uint256 indexed id, address indexed lender, address indexed borrower, uint256 lenderCollateral, uint256 borrowerCollateral);
+    event MatchOrderConverted(
+        uint256 indexed id,
+        address indexed lender,
+        address indexed borrower,
+        uint256 lenderCollateral,
+        uint256 borrowerCollateral
+    );
 
     /**
      * @notice Emitted when the market maker swaps in rwa tokens for assets.

--- a/src/interfaces/IBloomPool.sol
+++ b/src/interfaces/IBloomPool.sol
@@ -56,14 +56,14 @@ interface IBloomPool is IOrderbook, IPoolStorage {
     //////////////////////////////////////////////////////////////*/
 
     /**
-     * @notice Emitted when a user kills a lend order.
+     * @notice Emitted when a lenders match order is converted to a live TBY.
      * @param id The unique identifier of the TBY.
-     * @param account The address of the user who created the lend order.
+     * @param lender The address of the user who created the lend order.
      * @param borrower The address of the borrower who filled the order.
-     * @param amount The amount of underlying assets returned to the user.
-     * @param borrowerCollateral The amount of collateral converted to borrower funds.
+     * @param lenderCollateral The amount of lender collateral converted.
+     * @param borrowerCollateral The amount of borrower collateral converted.
      */
-    event MatchOrderConverted(uint256 indexed id, address indexed account, address indexed borrower, uint256 amount, uint256 borrowerCollateral);
+    event MatchOrderConverted(uint256 indexed id, address indexed lender, address indexed borrower, uint256 lenderCollateral, uint256 borrowerCollateral);
 
     /**
      * @notice Emitted when the market maker swaps in rwa tokens for assets.

--- a/src/interfaces/IBloomPool.sol
+++ b/src/interfaces/IBloomPool.sol
@@ -56,6 +56,16 @@ interface IBloomPool is IOrderbook, IPoolStorage {
     //////////////////////////////////////////////////////////////*/
 
     /**
+     * @notice Emitted when a user kills a lend order.
+     * @param id The unique identifier of the TBY.
+     * @param account The address of the user who created the lend order.
+     * @param borrower The address of the borrower who filled the order.
+     * @param amount The amount of underlying assets returned to the user.
+     * @param borrowerCollateral The amount of collateral converted to borrower funds.
+     */
+    event MatchOrderConverted(uint256 indexed id, address indexed account, address indexed borrower, uint256 amount, uint256 borrowerCollateral);
+
+    /**
      * @notice Emitted when the market maker swaps in rwa tokens for assets.
      * @param id The unique identifier of the TBY.
      * @param account The address of the user who swapped in.


### PR DESCRIPTION
A new event called `MatchOrderConverted` has been added to the `BloomPool`. This was created to introduce more specific data tracking of borrower's live orders. In the original codebase we were simply reusing the `MatchOrderKilled` event which doesnt handle borrowers and individual collateral amounts in the best manner for tracking live TBYs.