### PR TITLE
Rate Fix

### DIFF
--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -462,7 +462,11 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
 
         // If the TBY has matured, and is not-eligible for redemption due to market maker delay,
         //     calculate price based on the current price of the RWA token via the price feed.
-        return ((_rwaPrice() * _spread) / rwaPrice.startPrice);
+        uint256 price = (_rwaPrice() * _spread) / rwaPrice.startPrice;
+
+        // The rate should never be less than 1e18. Rate will not accrue until both the lender and borrower can start
+        //     accruing interest.
+        return price > Math.WAD ? price : Math.WAD;
     }
 
     /// @inheritdoc IBloomPool

--- a/src/PoolStorage.sol
+++ b/src/PoolStorage.sol
@@ -67,8 +67,8 @@ abstract contract PoolStorage is IPoolStorage, Ownable2Step {
     /// @notice The upper bound leverage allowed for pool (Cant be set to 100x but just under).
     uint256 constant MAX_LEVERAGE = 100e18;
 
-    /// @notice Maximum spread between the TBY rate and the rate of the RWA's price appreciation.
-    uint256 constant MAX_SPREAD = 0.85e18;
+    /// @notice Minimum spread between the TBY rate and the rate of the RWA's price appreciation.
+    uint256 constant MIN_SPREAD = 0.85e18;
 
     /*///////////////////////////////////////////////////////////////
                             Modifiers    
@@ -199,7 +199,7 @@ abstract contract PoolStorage is IPoolStorage, Ownable2Step {
 
     /// @notice Internal logic to set the spread.
     function _setSpread(uint256 spread_) internal {
-        require(spread_ >= MAX_SPREAD, Errors.InvalidSpread());
+        require(spread_ >= MIN_SPREAD, Errors.InvalidSpread());
         _spread = spread_;
         emit SpreadSet(spread_);
     }


### PR DESCRIPTION
This PR updates `BloomPool:getRate` to only allow value accrual for the borrower in the event that the lender at least has a TBY value that is greater than 1. 

Additionally the `MAX_SPREAD` various was improperly labeled so it is being renamed to `MIN_SPREAD`.