### PR TITLE
Octane Audit | L-1 Price Feed Protection

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -35,13 +35,13 @@ contract DeployScript is Script {
         require(leverage != 0, "Leverage is not set");
         require(spread != 0, "Spread is not set");
 
-        BloomPool bloomPool = new BloomPool(stable, rwa, rwaPriceFeed, leverage, spread, owner);
+        BloomPool bloomPool = new BloomPool(stable, rwa, rwaPriceFeed, 1 days,leverage, spread, owner);
         console.log("BloomPool: ", address(bloomPool));
 
         require(bloomPool.owner() != address(0), "Deployer is not owner");
         require(bloomPool.asset() == address(stable), "Stable is not set");
         require(bloomPool.rwa() == address(rwa), "BillToken is not set");
-        require(bloomPool.rwaPriceFeed() == address(rwaPriceFeed), "PriceFeed is not set");
+        require(bloomPool.rwaPriceFeed().priceFeed == address(rwaPriceFeed), "PriceFeed is not set");
         require(bloomPool.leverage() == leverage, "Init leverage is not set");
         require(bloomPool.spread() == spread, "Spread is not set");
 

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -35,7 +35,7 @@ contract DeployScript is Script {
         require(leverage != 0, "Leverage is not set");
         require(spread != 0, "Spread is not set");
 
-        BloomPool bloomPool = new BloomPool(stable, rwa, rwaPriceFeed, 1 days,leverage, spread, owner);
+        BloomPool bloomPool = new BloomPool(stable, rwa, rwaPriceFeed, 1 days, leverage, spread, owner);
         console.log("BloomPool: ", address(bloomPool));
 
         require(bloomPool.owner() != address(0), "Deployer is not owner");

--- a/script/DeployTestnet.s.sol
+++ b/script/DeployTestnet.s.sol
@@ -45,6 +45,7 @@ contract DeployScript is Script {
             address(stable),
             address(billToken),
             address(priceFeed),
+            1 days,
             50e18, // 50x leverage
             0.995e18, // .5% spread for borrow return
             owner
@@ -54,7 +55,7 @@ contract DeployScript is Script {
         require(bloomPool.owner() != address(0), "Deployer is not owner");
         require(bloomPool.asset() == address(stable), "Stable is not set");
         require(bloomPool.rwa() == address(billToken), "BillToken is not set");
-        require(bloomPool.rwaPriceFeed() == address(priceFeed), "PriceFeed is not set");
+        require(bloomPool.rwaPriceFeed().priceFeed == address(priceFeed), "PriceFeed is not set");
         require(bloomPool.leverage() == 50e18, "Init leverage is not set");
         require(bloomPool.spread() == 0.995e18, "Spread is not set");
 

--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -344,6 +344,7 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
     function _rwaPrice() private view returns (uint256) {
         (uint80 roundId, int256 answer,, uint256 updatedAt, uint80 answeredInRound) =
             AggregatorV3Interface(_rwaPriceFeed).latestRoundData();
+        require(answer > 0, Errors.InvalidPriceFeed());
         require(updatedAt >= block.timestamp - 1 days, Errors.OutOfDate());
         require(answeredInRound >= roundId, Errors.OutOfDate());
 

--- a/src/interfaces/IBloomPool.sol
+++ b/src/interfaces/IBloomPool.sol
@@ -51,6 +51,18 @@ interface IBloomPool is IOrderbook, IPoolStorage {
         uint128 endPrice;
     }
 
+    /**
+     * @notice Struct to store the price feed for an RWA.
+     * @param priceFeed The address of the price feed.
+     * @param updateInterval The interval in seconds at which the price feed should be updated.
+     * @param decimals The number of decimals the price feed returns.
+     */
+    struct RwaPriceFeed {
+        address priceFeed;
+        uint64 updateInterval;
+        uint8 decimals;
+    }
+
     /*///////////////////////////////////////////////////////////////
                             Events
     //////////////////////////////////////////////////////////////*/
@@ -154,8 +166,8 @@ interface IBloomPool is IOrderbook, IPoolStorage {
     /// @notice Returns the length of time that the next minted TBY Id will mature for. Default is 180 days.
     function futureMaturity() external view returns (uint256);
 
-    /// @notice Returns the RWAs price feed address.
-    function rwaPriceFeed() external view returns (address);
+    /// @notice Returns the RWAs price feed struct.
+    function rwaPriceFeed() external view returns (RwaPriceFeed memory);
 
     /// @notice Returns the TbyCollateral struct containing the breakdown of collateral for a given Tby ID.
     function tbyCollateral(uint256 id) external view returns (TbyCollateral memory);

--- a/test/BloomTestSetup.t.sol
+++ b/test/BloomTestSetup.t.sol
@@ -54,7 +54,7 @@ abstract contract BloomTestSetup is Test {
         priceFeed.setLatestRoundData(1, 110e8, 0, block.timestamp, 1);
 
         bloomPool = new BloomPool(
-            address(stable), address(billToken), address(priceFeed), initialLeverage, initialSpread, owner
+            address(stable), address(billToken), address(priceFeed), 1 days, initialLeverage, initialSpread, owner
         );
         vm.stopPrank();
 

--- a/test/Unit/BloomUnitTest.t.sol
+++ b/test/Unit/BloomUnitTest.t.sol
@@ -28,18 +28,19 @@ contract BloomUnitTest is BloomTestSetup {
 
     function testDeployment() public {
         BloomPool newPool = new BloomPool(
-            address(stable), address(billToken), address(priceFeed), initialLeverage, initialSpread, owner
+            address(stable), address(billToken), address(priceFeed), 1 days,initialLeverage, initialSpread, owner
         );
         assertNotEq(address(newPool), address(0));
-        assertEq(newPool.rwaPriceFeed(), address(priceFeed));
+        assertEq(newPool.rwaPriceFeed().priceFeed, address(priceFeed));
         assertEq(newPool.futureMaturity(), 180 days);
     }
 
     function testSetPriceFeedNonOwner() public {
         /// Expect revert if not owner calls
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(this)));
-        bloomPool.setPriceFeed(address(1));
-        assertEq(bloomPool.rwaPriceFeed(), address(priceFeed));
+        bloomPool.setPriceFeed(address(1), 2 days);
+        assertEq(bloomPool.rwaPriceFeed().priceFeed, address(priceFeed));
+        assertEq(bloomPool.rwaPriceFeed().updateInterval, 1 days);
     }
 
     function testSetMaturityNonOwner() public {
@@ -53,7 +54,7 @@ contract BloomUnitTest is BloomTestSetup {
         vm.startPrank(owner);
         vm.expectEmit(false, false, false, true);
         emit IBloomPool.RwaPriceFeedSet(address(priceFeed));
-        bloomPool.setPriceFeed(address(priceFeed));
+        bloomPool.setPriceFeed(address(priceFeed), 1 days);
     }
 
     function testSetPriceFeedRevert() public {
@@ -61,17 +62,17 @@ contract BloomUnitTest is BloomTestSetup {
         // Revert if price is 0
         priceFeed.setLatestRoundData(0, 0, 0, 0, 0);
         vm.expectRevert(Errors.InvalidPriceFeed.selector);
-        bloomPool.setPriceFeed(address(priceFeed));
+        bloomPool.setPriceFeed(address(priceFeed), 1 days);
 
         // Revert if feed hasnt been updated in a while
         priceFeed.setLatestRoundData(0, 1, 0, 0, 0);
         vm.expectRevert(Errors.OutOfDate.selector);
-        bloomPool.setPriceFeed(address(priceFeed));
+        bloomPool.setPriceFeed(address(priceFeed), 1 days);
 
         // Revert if feed hasnt has the wrong round id
         priceFeed.setLatestRoundData(1, 1, 0, 0, 0);
         vm.expectRevert(Errors.OutOfDate.selector);
-        bloomPool.setPriceFeed(address(priceFeed));
+        bloomPool.setPriceFeed(address(priceFeed), 1 days);
     }
 
     function testSetMaturitySuccess() public {

--- a/test/Unit/BloomUnitTest.t.sol
+++ b/test/Unit/BloomUnitTest.t.sol
@@ -28,7 +28,7 @@ contract BloomUnitTest is BloomTestSetup {
 
     function testDeployment() public {
         BloomPool newPool = new BloomPool(
-            address(stable), address(billToken), address(priceFeed), 1 days,initialLeverage, initialSpread, owner
+            address(stable), address(billToken), address(priceFeed), 1 days, initialLeverage, initialSpread, owner
         );
         assertNotEq(address(newPool), address(0));
         assertEq(newPool.rwaPriceFeed().priceFeed, address(priceFeed));


### PR DESCRIPTION
Within the `BloomPool`, Chainlink price feeds can return zero values. This issue has been mitigated with a `price > 0` check. Additionally in order to support any RWA price feed custom `priceFeedUpdateInterval`s have been set up to give the owner of the contract more customizability on staleness checks depending on their use case. The initial use case for this contract will be the `bib01` price feed which as 24 hour update cadence. 

The `RwaPriceFeed` struct has also been added to fetch all necessary price feed info in a single storage read operation.