### PR TITLE
Octane Audit | G-2: Functions can be marked as external

### DIFF
--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -272,7 +272,7 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
      * @dev Only the owner can call this function.
      * @param rwaPriceFeed_ The address of the price feed for the RWA token.
      */
-    function setPriceFeed(address rwaPriceFeed_) public onlyOwner {
+    function setPriceFeed(address rwaPriceFeed_) external onlyOwner {
         _setPriceFeed(rwaPriceFeed_);
     }
 

--- a/src/Orderbook.sol
+++ b/src/Orderbook.sol
@@ -110,7 +110,7 @@ abstract contract Orderbook is IOrderbook, PoolStorage {
     }
 
     /// @inheritdoc IOrderbook
-    function killMatchOrder(uint256 amount) public returns (uint256 totalRemoved) {
+    function killMatchOrder(uint256 amount) external returns (uint256 totalRemoved) {
         _amountZeroCheck(amount);
         // if the order is already matched we have to account for the borrower's who filled the order.
         // If you kill a match order and there are multiple borrowers, the order will be closed in a LIFO manner.
@@ -274,7 +274,7 @@ abstract contract Orderbook is IOrderbook, PoolStorage {
     }
 
     /// @inheritdoc IOrderbook
-    function idleCapital(address account) public view returns (uint256) {
+    function idleCapital(address account) external view returns (uint256) {
         return _idleCapital[account];
     }
 }

--- a/src/PoolStorage.sol
+++ b/src/PoolStorage.sol
@@ -138,7 +138,7 @@ abstract contract PoolStorage is IPoolStorage, Ownable2Step {
      * @dev Leverage is scaled to 1e18. (20x leverage = 20e18)
      * @param leverage Updated leverage
      */
-    function setLeverage(uint256 leverage) public onlyOwner {
+    function setLeverage(uint256 leverage) external onlyOwner {
         _setLeverage(leverage);
     }
 
@@ -146,7 +146,7 @@ abstract contract PoolStorage is IPoolStorage, Ownable2Step {
      * @notice Updates the spread between the TBY rate and the RWA rate.
      * @param spread_ The new spread value.
      */
-    function setSpread(uint256 spread_) public onlyOwner {
+    function setSpread(uint256 spread_) external onlyOwner {
         _setSpread(spread_);
     }
 


### PR DESCRIPTION
Within the `BloomPool`, `Orderbook`, and `PoolStorage` contracts there are several functions that can be marked `external` instead of `public` in order to save gas. Below are the functions which have been updated to reflect this change.

- `setPriceFeed`
- `killMatchOrder`
- `idleCapital`
- `setLeverage`
- `setSpread`