### PR TITLE
Octane Audit | H-2: Lenders can lock borrower's funds for an indefinite period.

### DIFF
--- a/src/Orderbook.sol
+++ b/src/Orderbook.sol
@@ -181,10 +181,21 @@ abstract contract Orderbook is IOrderbook, PoolStorage {
 
         borrowAmount = filled.divWad(_leverage);
 
-        _userMatchedOrders[account].push(
+        MatchOrder[] storage matches = _userMatchedOrders[account];
+        uint256 len = matches.length;
+
+        for (uint256 i = 0; i != len; ++i) {
+            if (matches[i].borrower == msg.sender) {
+                matches[i].lCollateral += uint128(filled);
+                matches[i].bCollateral += uint128(borrowAmount);
+                emit OrderFilled(account, msg.sender, _leverage, filled);
+                return (filled, borrowAmount);
+            }
+        }
+
+        matches.push(
             MatchOrder({lCollateral: uint128(filled), bCollateral: uint128(borrowAmount), borrower: msg.sender})
         );
-
         emit OrderFilled(account, msg.sender, _leverage, filled);
     }
 

--- a/src/Orderbook.sol
+++ b/src/Orderbook.sol
@@ -115,25 +115,25 @@ abstract contract Orderbook is IOrderbook, PoolStorage {
     }
 
     /// @inheritdoc IOrderbook
-    function killBorrowerMatch(address lender) external returns (uint256 lenderReturn, uint256 borrowerReturn) {
+    function killBorrowerMatch(address lender) external returns (uint256 lenderAmount, uint256 borrowerReturn) {
         MatchOrder[] storage matches = _userMatchedOrders[lender];
 
         uint256 len = matches.length;
         for (uint256 i = 0; i != len; ++i) {
             if (matches[i].borrower == msg.sender) {
-                lenderReturn = uint256(matches[i].lCollateral);
+                lenderAmount = uint256(matches[i].lCollateral);
                 borrowerReturn = uint256(matches[i].bCollateral);
                 // Zero out the match order to preserve the array's order
                 matches[i] = MatchOrder({lCollateral: 0, bCollateral: 0, borrower: address(0)});
                 // Decrement the matched depth and open move the lenders collateral to an open order.
-                _matchedDepth -= lenderReturn;
-                _openOrder(lender, lenderReturn);
+                _matchedDepth -= lenderAmount;
+                _openOrder(lender, lenderAmount);
                 break;
             }
         }
 
-        require(lenderReturn != 0, Errors.MatchOrderNotFound());
-        emit MatchOrderKilled(lender, msg.sender, lenderReturn);
+        require(lenderAmount != 0, Errors.MatchOrderNotFound());
+        emit MatchOrderKilled(lender, msg.sender, lenderAmount);
 
         IERC20(_asset).safeTransfer(msg.sender, borrowerReturn);
     }

--- a/src/helpers/BloomErrors.sol
+++ b/src/helpers/BloomErrors.sol
@@ -44,6 +44,9 @@ library BloomErrors {
     ///         Amount post leverage must be greater than 0.
     error InvalidMatchSize();
 
+    /// @notice Emitted when a borrower tries to kill a match order that does not exist.
+    error MatchOrderNotFound();
+
     /*///////////////////////////////////////////////////////////////
                             KYC Errors    
     //////////////////////////////////////////////////////////////*/

--- a/src/interfaces/IOrderbook.sol
+++ b/src/interfaces/IOrderbook.sol
@@ -134,7 +134,7 @@ interface IOrderbook {
 
     /**
      * @notice Allows borrowers to cancel their match orders and withdraw their underlying assets.
-     * @dev When borrower cancels a match order, funds are returned to both the lender and borrower.
+     * @dev When borrower cancels a match order, funds are returned borrower and the matched order is converted to an open order.
      * @dev There is no idle capital conversion in this operation.
      * @dev Borrower's must kill the entirity of the match order.
      * @param lender The address of the lender to cancel the match order for.

--- a/src/interfaces/IOrderbook.sol
+++ b/src/interfaces/IOrderbook.sol
@@ -138,10 +138,10 @@ interface IOrderbook {
      * @dev There is no idle capital conversion in this operation.
      * @dev Borrower's must kill the entirity of the match order.
      * @param lender The address of the lender to cancel the match order for.
-     * @return lenderReturn The total amount of underlying assets removed from the order.
+     * @return lenderAmount The total amount of underlying assets converted from the match order to an open order.
      * @return borrowerReturn The total amount of underlying assets removed from the order.
      */
-    function killBorrowerMatch(address lender) external returns (uint256 lenderReturn, uint256 borrowerReturn);
+    function killBorrowerMatch(address lender) external returns (uint256 lenderAmount, uint256 borrowerReturn);
 
     /// @notice Returns the current leverage value for the borrower scaled to 1e4.
     function leverage() external view returns (uint256);

--- a/src/interfaces/IOrderbook.sol
+++ b/src/interfaces/IOrderbook.sol
@@ -125,12 +125,23 @@ interface IOrderbook {
     function killOpenOrder(uint256 amount) external;
 
     /**
-     * @notice Allows users to cancel their match lend orders and withdraw their underlying assets.
+     * @notice Allows Lenders to cancel their match orders and withdraw their underlying assets.
      * @dev If an order is matched by multiple borrowers, borrower matches must be closed fully in a LIFO manner.
      * @param amount The amount of underlying assets to remove from your order.
      * @return totalRemoved The total amount of underlying assets removed from the order.
      */
     function killMatchOrder(uint256 amount) external returns (uint256 totalRemoved);
+
+    /**
+     * @notice Allows borrowers to cancel their match orders and withdraw their underlying assets.
+     * @dev When borrower cancels a match order, funds are returned to both the lender and borrower.
+     * @dev There is no idle capital conversion in this operation.
+     * @dev Borrower's must kill the entirity of the match order.
+     * @param lender The address of the lender to cancel the match order for.
+     * @return lenderReturn The total amount of underlying assets removed from the order.
+     * @return borrowerReturn The total amount of underlying assets removed from the order.
+     */
+    function killBorrowerMatch(address lender) external returns (uint256 lenderReturn, uint256 borrowerReturn);
 
     /// @notice Returns the current leverage value for the borrower scaled to 1e4.
     function leverage() external view returns (uint256);

--- a/test/Fuzz/OrderbookFuzzTest.t.sol
+++ b/test/Fuzz/OrderbookFuzzTest.t.sol
@@ -294,6 +294,18 @@ contract OrderbookFuzzTest is BloomTestSetup {
         assertEq(stable.balanceOf(borrower), borrowBalanceBefore + withdrawAmount);
     }
 
+    function testFuzz_KillBorrowerMatch(uint256 orderSize) public {
+        orderSize = bound(orderSize, 1e6, 1_000_000e6);
+
+        _createLendOrder(alice, orderSize);
+        _fillOrder(alice, orderSize);
+
+        vm.startPrank(borrower);
+        vm.expectEmit(true, true, false, true);
+        emit IOrderbook.MatchOrderKilled(alice, borrower, orderSize);
+        bloomPool.killBorrowerMatch(alice);
+    }
+
     function testFuzz_FillOrderWithIdleCapital(uint256 orderSize) public {
         orderSize = bound(orderSize, 1e6, 1_000_000e6);
 

--- a/test/Fuzz/OrderbookFuzzTest.t.sol
+++ b/test/Fuzz/OrderbookFuzzTest.t.sol
@@ -304,6 +304,11 @@ contract OrderbookFuzzTest is BloomTestSetup {
         vm.expectEmit(true, true, false, true);
         emit IOrderbook.MatchOrderKilled(alice, borrower, orderSize);
         bloomPool.killBorrowerMatch(alice);
+
+        assertEq(bloomPool.openDepth(), orderSize);
+        assertEq(bloomPool.matchedDepth(), 0);
+        assertEq(bloomPool.amountOpen(alice), orderSize);
+        assertEq(bloomPool.amountMatched(alice), 0);
     }
 
     function testFuzz_FillOrderWithIdleCapital(uint256 orderSize) public {

--- a/test/Unit/OrderbookUnitTest.t.sol
+++ b/test/Unit/OrderbookUnitTest.t.sol
@@ -91,14 +91,14 @@ contract OrderbookUnitTest is BloomTestSetup {
 
         // Validate pool state
         assertEq(bloomPool.matchedDepth(), 0);
-        assertEq(bloomPool.openDepth(), 0);
+        assertEq(bloomPool.openDepth(), 100e6);
         assertEq(postCancelMatchedOrder.bCollateral, 0);
         assertEq(postCancelMatchedOrder.lCollateral, 0);
         assertEq(postCancelMatchedOrder.borrower, address(0));
 
         // Validate balances
         assertEq(stable.balanceOf(borrower), borrowerPreBalance + matchedOrder.bCollateral);
-        assertEq(stable.balanceOf(alice), alicePreBalance + matchedOrder.lCollateral);
+        assertEq(stable.balanceOf(alice), alicePreBalance);
     }
 
     function testKillBorrowerOrderNoMatch() public {


### PR DESCRIPTION
`BloomPool` currently lacks functionality for borrowers to cancel their match orders. Moreover, if the lender's account is a contract, the lender could potentially exploit a vulnerability by implementing a revert in the ERC-1155 receiver fallback function. This could prevent `KycMarketMakers` from converting the lend order, effectively locking the borrower's capital within the contract until the lender cancels their order.

This PR mitigates this issue by allowing borrowers to cancel match orders using the new `killBorrowerMatch` function.