### PR TITLE
Refactor SwapOut and getRate functions

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -19,8 +19,12 @@ gas_reports_ignore = ["MockERC20", "BloomTestSetup"]
 [rpc_endpoints]
 arbitrum = "${ARB_RPC_URL}"
 arbitrum_sepolia = "${ARB_SEPOLIA_RPC_URL}"
+base = "${BASE_RPC_URL}"
+base_sepolia = "${BASE_SEPOLIA_RPC_URL}"
 anvil = "${ANVIL_RPC_URL}"
 
 [etherscan]
 arbitrum = { key = "${ARBITRUM_API_KEY}" }
 arbitrum_sepolia = { key = "${ARBITRUM_API_KEY}" }
+base = { key = "${BASESCAN_API_KEY}" }
+base_sepolia = { key = "${BASESCAN_API_KEY}" }

--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -19,7 +19,6 @@ import {BloomErrors as Errors} from "@bloom-v2/helpers/BloomErrors.sol";
 
 import {Orderbook} from "@bloom-v2/Orderbook.sol";
 import {IBloomPool} from "@bloom-v2/interfaces/IBloomPool.sol";
-import {console2} from "forge-std/console2.sol";
 
 /**
  * @title BloomPool
@@ -452,6 +451,7 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
         borrowerFunds = remainingAmount - lenderFunds;
     }
 
+    /// @notice Takes removes the borrower's interest earned off the yield of the RWA token in order to calculate the TBY rate.
     function _takeSpread(uint256 rate) internal view returns (uint256) {
         if (rate > Math.WAD) {
             uint256 yield = rate - Math.WAD;

--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -219,7 +219,7 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
         // Calculate the percentage of RWA tokens that are being currently swapped
         uint256 percentSwapped = rwaAmount.divWad(totalRwaCollateral);
         require(percentSwapped >= MIN_SWAP_OUT_PERCENT, Errors.SwapOutTooSmall());
-        
+
         uint256 tbyTotalSupply = _tby.totalSupply(id);
         uint256 tbyAmount = percentSwapped != Math.WAD ? tbyTotalSupply.mulWadUp(percentSwapped) : tbyTotalSupply;
         require(tbyAmount > 0, Errors.ZeroAmount());

--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -218,7 +218,8 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
 
         // Calculate the percentage of RWA tokens that are being currently swapped
         uint256 percentSwapped = rwaAmount.divWad(totalRwaCollateral);
-        require(percentSwapped >= MIN_SWAP_OUT_PERCENT, Errors.SwapOutTooSmall());
+        uint256 percentOfLiquidity = rwaAmount.divWad(collateral.rwaAmount);
+        require(percentOfLiquidity >= MIN_SWAP_OUT_PERCENT, Errors.SwapOutTooSmall());
 
         uint256 tbyTotalSupply = _tby.totalSupply(id);
         uint256 tbyAmount = percentSwapped != Math.WAD ? tbyTotalSupply.mulWadUp(percentSwapped) : tbyTotalSupply;

--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -77,6 +77,9 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
     /// @notice The default length of time that TBYs mature.
     uint256 constant DEFAULT_MATURITY = 180 days;
 
+    /// @notice The minimum percentage of RWA tokens that must be swapped out in a single `swapOut` call. (0.25% of total RWA collateral for the TBY)
+    uint256 constant MIN_SWAP_OUT_PERCENT = 0.0025e18;
+
     /*///////////////////////////////////////////////////////////////
                             Modifiers   
     //////////////////////////////////////////////////////////////*/
@@ -215,7 +218,8 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
 
         // Calculate the percentage of RWA tokens that are being currently swapped
         uint256 percentSwapped = rwaAmount.divWad(totalRwaCollateral);
-
+        require(percentSwapped >= MIN_SWAP_OUT_PERCENT, Errors.SwapOutTooSmall());
+        
         uint256 tbyTotalSupply = _tby.totalSupply(id);
         uint256 tbyAmount = percentSwapped != Math.WAD ? tbyTotalSupply.mulWadUp(percentSwapped) : tbyTotalSupply;
         require(tbyAmount > 0, Errors.ZeroAmount());

--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -237,8 +237,8 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
             if (lenderReturn > assetAmount) {
                 lenderReturn = assetAmount;
                 uint256 accumulatedCollateral = _tbyLenderReturns[id] + lenderReturn;
-                uint256 remainingRwa = (collateral.rwaAmount - rwaAmount).mulWad(currentPrice);
-                uint256 totalCollateral = accumulatedCollateral + remainingRwa;
+                uint256 remainingAmount = (collateral.rwaAmount - rwaAmount).mulWad(currentPrice) / _assetScalingFactor;
+                uint256 totalCollateral = accumulatedCollateral + remainingAmount;
                 uint256 newRate = totalCollateral.divWad(_tby.totalSupply(id));
                 uint256 adjustedRate = _takeSpread(newRate);
                 rwaPrice.endPrice = uint128(adjustedRate.mulWad(rwaPrice.startPrice));

--- a/src/helpers/BloomErrors.sol
+++ b/src/helpers/BloomErrors.sol
@@ -30,6 +30,9 @@ library BloomErrors {
     /// @notice Emitted when getting the price of a Tby that does not exist.
     error InvalidTby();
 
+    /// @notice Emitted when a market maker tries to swap out too small of a percentage of RWA tokens.
+    error SwapOutTooSmall();
+
     /*///////////////////////////////////////////////////////////////
                             Orderbook Errors    
     //////////////////////////////////////////////////////////////*/

--- a/test/Fuzz/BloomPoolFuzzTest.t.sol
+++ b/test/Fuzz/BloomPoolFuzzTest.t.sol
@@ -18,8 +18,6 @@ import {BloomErrors as Errors} from "@bloom-v2/helpers/BloomErrors.sol";
 import {IOrderbook} from "@bloom-v2/interfaces/IOrderbook.sol";
 import {IBloomPool} from "@bloom-v2/interfaces/IBloomPool.sol";
 
-import {console2} from "forge-std/console2.sol";
-
 contract BloomPoolFuzzTest is BloomTestSetup {
     using FpMath for uint256;
 
@@ -250,8 +248,7 @@ contract BloomPoolFuzzTest is BloomTestSetup {
         // Validate Lender and Borrower returns
         uint256 tbyRate = bloomPool.getRate(0);
         uint256 tbyAmount = tby.totalSupply(0);
-        console2.log("tbyAmount", tbyAmount);
-        console2.log("tbyRate", tbyRate);
+
         uint256 expectedLenderReturns = tbyAmount.mulWad(tbyRate);
         uint256 expectedBorrowerReturns = amountNeeeded - expectedLenderReturns;
 

--- a/test/Fuzz/BloomPoolFuzzTest.t.sol
+++ b/test/Fuzz/BloomPoolFuzzTest.t.sol
@@ -18,6 +18,8 @@ import {BloomErrors as Errors} from "@bloom-v2/helpers/BloomErrors.sol";
 import {IOrderbook} from "@bloom-v2/interfaces/IOrderbook.sol";
 import {IBloomPool} from "@bloom-v2/interfaces/IBloomPool.sol";
 
+import {console2} from "forge-std/console2.sol";
+
 contract BloomPoolFuzzTest is BloomTestSetup {
     using FpMath for uint256;
 
@@ -246,10 +248,11 @@ contract BloomPoolFuzzTest is BloomTestSetup {
         assertEq(rwaPricing.endPrice, 112e18);
 
         // Validate Lender and Borrower returns
-        uint256 tbyTotalSupply = tby.totalSupply(0);
         uint256 tbyRate = bloomPool.getRate(0);
-
-        uint256 expectedLenderReturns = tbyTotalSupply.mulWad(tbyRate);
+        uint256 tbyAmount = tby.totalSupply(0);
+        console2.log("tbyAmount", tbyAmount);
+        console2.log("tbyRate", tbyRate);
+        uint256 expectedLenderReturns = tbyAmount.mulWad(tbyRate);
         uint256 expectedBorrowerReturns = amountNeeeded - expectedLenderReturns;
 
         assertEq(bloomPool.lenderReturns(0), expectedLenderReturns);

--- a/test/Unit/BloomUnitTest.t.sol
+++ b/test/Unit/BloomUnitTest.t.sol
@@ -300,4 +300,64 @@ contract BloomUnitTest is BloomTestSetup {
         // sending additional tokens but can be any value.
         _swapOut(0, 2700e6);
     }
+
+    function testSmallSwapAtEndOfMultipleSwapOuts() external {
+        uint256 amount = 1000e6;
+
+        address borrower2 = makeAddr("borrower2");
+        address marketMaker2 = makeAddr("marketMaker2");
+
+        vm.startPrank(owner);
+        bloomPool.whitelistBorrower(borrower, true);
+        bloomPool.whitelistMarketMaker(marketMaker, true);
+        bloomPool.whitelistBorrower(borrower2, true);
+        bloomPool.whitelistMarketMaker(marketMaker2, true);
+
+        uint256 beforealice = stable.balanceOf(address(alice));
+        assert(beforealice == 0);
+
+        _createLendOrder(address(alice), amount);
+        _createLendOrder(address(bob), amount);
+        _createLendOrder(address(rando), amount);
+
+        beforealice = stable.balanceOf(address(alice));
+        assert(beforealice == 0);
+        uint256 borrowamount = 100e6;
+
+        _fillOrderWithCustomBorrower(address(alice), borrowamount, address(borrower));
+        _fillOrderWithCustomBorrower(address(bob), borrowamount, address(borrower));
+        _fillOrderWithCustomBorrower(address(rando), borrowamount, address(borrower));
+
+        _fillOrderWithCustomBorrower(address(alice), amount, address(borrower2));
+        _fillOrderWithCustomBorrower(address(bob), amount, address(borrower2));
+        _fillOrderWithCustomBorrower(address(rando), amount, address(borrower2));
+
+        assert(bloomPool.lastMintedId() == type(uint256).max);
+
+        vm.prank(alice);
+        bloomPool.killMatchOrder(1000e6 - 500e6);
+
+        lenders.push(alice);
+        lenders.push(bob);
+        lenders.push(rando);
+
+        _swapInWithCustomMarketMaker(1000e6, marketMaker);
+        vm.stopPrank();
+
+        _swapInWithCustomMarketMaker(100, marketMaker2);
+        vm.stopPrank();
+
+        skip(180 days);
+
+        vm.startPrank(owner);
+        priceFeed.setLatestRoundData(1, 110e8, 0, block.timestamp, 1);
+
+        uint256 asset_amount;
+        asset_amount = _swapOutWithCustomMarketMaker(0, 500e6, marketMaker);
+        asset_amount = _swapOutWithCustomMarketMaker(0, 500e6, marketMaker);
+
+        _swapOutWithCustomMarketMaker(0, 500, marketMaker2);
+        assertEq(bloomPool.tbyCollateral(0).rwaAmount, 0);
+        assertEq(bloomPool.isTbyRedeemable(0), true);
+    }
 }

--- a/test/Unit/BloomUnitTest.t.sol
+++ b/test/Unit/BloomUnitTest.t.sol
@@ -114,7 +114,8 @@ contract BloomUnitTest is BloomTestSetup {
         uint256 newRate = 115e8;
         _skipAndUpdatePrice(3 days, newRate, 1);
 
-        uint256 expectedRate = 115e18 * initialSpread / 110e18; // 110e18 is the initial rate
+        uint256 priceAppreciation = (uint256(newRate).divWad(110e8)) - FpMath.WAD;
+        uint256 expectedRate = FpMath.WAD + ((priceAppreciation).mulWad(initialSpread));
         assertEq(bloomPool.getRate(0), expectedRate);
     }
 
@@ -262,5 +263,41 @@ contract BloomUnitTest is BloomTestSetup {
         assertEq(bloomPool.tbyMaturity(0).end, expectedTby0Maturity);
         // Validate that the maturity of the second TBY is 10 days
         assertEq(bloomPool.tbyMaturity(1).end, block.timestamp + 10 days);
+    }
+
+    function testSwapOutExtraCall() external {
+        vm.startPrank(owner);
+        bloomPool.whitelistMarketMaker(marketMaker, true);
+        bloomPool.whitelistBorrower(borrower, true);
+
+        uint256 lendamt = 1000e6;
+        _createLendOrder(alice, lendamt);
+        _createLendOrder(bob, lendamt);
+
+        _fillOrder(alice, lendamt);
+        _fillOrder(bob, lendamt);
+
+        lenders.push(alice);
+        lenders.push(bob);
+
+        uint256 swapamt = 20000e18;
+        _swapIn(swapamt);
+        vm.stopPrank();
+
+        assert(stable.balanceOf(address(bloomPool)) == 0);
+        assert(stable.balanceOf(address(marketMaker)) == 2040000000);
+        assert(billToken.balanceOf(address(bloomPool)) == 18545454545454545455);
+        assert(tby.balanceOf(address(bloomPool), 0) == 0);
+        uint256 DEFAULT_MATURITY = 180 days;
+
+        skip(DEFAULT_MATURITY);
+
+        vm.startPrank(owner);
+        priceFeed.setLatestRoundData(1, 110e8, 0, block.timestamp, 1);
+
+        _swapOut(0, 300e6);
+
+        // sending additional tokens but can be any value.
+        _swapOut(0, 2700e6);
     }
 }


### PR DESCRIPTION
There is a bug in the `swapOut` function that caused the `tbyAmount` value to be overvalued. This was due to not properly calculating `percentSwapped `. The following changes fix this issue by calculated the `totalRwaCollateral` that has been allocated to a given `tbyId` then calculating `percentSwapped`. 

Additionally, due to the `_spread` having too large of an impact on lender's returns during the previous method of calculating `getRate`, it has been decided to apply the `_spread` only to the yield accrued on `TBY`s, instead of on the entire rate calculation.  

The `MIN_SWAP_OUT_PERCENT` constant is also applied in order to protect from unwanted dust in the contract from extremely small swaps.