### PR TITLE
store starting RWA collateral within the TbyCollateral struct

### DIFF
--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -183,7 +183,6 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
 
         // Update the collateral for the TBY id.
         collateral.currentRwaAmount += uint128(rwaAmount);
-        collateral.startRwaAmount = collateral.currentRwaAmount;
 
         emit MarketMakerSwappedIn(id, msg.sender, rwaAmount, amountSwapped);
 
@@ -214,8 +213,13 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
             rwaPrice.endPrice = uint128(currentPrice);
         }
 
+        // If this is the first swap out for the TBY, we need to set the originalRwaAmount to the currentRwaAmount.
+        if (collateral.originalRwaAmount == 0) {
+            collateral.originalRwaAmount = collateral.currentRwaAmount;
+        }
+
         // Calculate the percentage of RWA tokens that are being currently swapped
-        uint256 percentSwapped = rwaAmount.divWad(collateral.startRwaAmount);
+        uint256 percentSwapped = rwaAmount.divWad(collateral.originalRwaAmount);
         uint256 percentOfLiquidity = rwaAmount.divWad(collateral.currentRwaAmount);
         require(percentOfLiquidity >= MIN_SWAP_OUT_PERCENT, Errors.SwapOutTooSmall());
 

--- a/src/interfaces/IBloomPool.sol
+++ b/src/interfaces/IBloomPool.sol
@@ -24,11 +24,13 @@ interface IBloomPool is IOrderbook, IPoolStorage {
     /**
      * @notice Struct representing the collateral backed by a TBY.
      * @param assetAmount The amount of underlying asset collateral.
-     * @param rwaAmount The amount of rwa asset collateral.
+     * @param startRwaAmount The amount of rwa asset collateral at the start of the TBY.
+     * @param currentRwaAmount The amount of rwa asset collateral at the current time.
      */
     struct TbyCollateral {
         uint128 assetAmount;
-        uint128 rwaAmount;
+        uint128 startRwaAmount;
+        uint128 currentRwaAmount;
     }
 
     /**

--- a/src/interfaces/IBloomPool.sol
+++ b/src/interfaces/IBloomPool.sol
@@ -24,13 +24,13 @@ interface IBloomPool is IOrderbook, IPoolStorage {
     /**
      * @notice Struct representing the collateral backed by a TBY.
      * @param assetAmount The amount of underlying asset collateral.
-     * @param startRwaAmount The amount of rwa asset collateral at the start of the TBY.
      * @param currentRwaAmount The amount of rwa asset collateral at the current time.
+     * @param originalRwaAmount The amount of rwa asset collateral at the start of the TBY (will only be set at the end of the TBYs maturity for accounting purposes)
      */
     struct TbyCollateral {
         uint128 assetAmount;
-        uint128 startRwaAmount;
         uint128 currentRwaAmount;
+        uint128 originalRwaAmount;
     }
 
     /**

--- a/test/Fuzz/BloomPoolFuzzTest.t.sol
+++ b/test/Fuzz/BloomPoolFuzzTest.t.sol
@@ -64,7 +64,7 @@ contract BloomPoolFuzzTest is BloomTestSetup {
         assertEq(bloomPool.matchedOrderCount(alice), 0);
 
         assertEq(bloomPool.tbyCollateral(0).assetAmount, 0);
-        assertEq(bloomPool.tbyCollateral(0).rwaAmount, rwaAmount);
+        assertEq(bloomPool.tbyCollateral(0).currentRwaAmount, rwaAmount);
 
         assertEq(bloomPool.tbyRwaPricing(0).startPrice, answerScaled);
         assertEq(bloomPool.tbyRwaPricing(0).endPrice, 0);
@@ -194,7 +194,7 @@ contract BloomPoolFuzzTest is BloomTestSetup {
         assertEq(bloomPool.matchedDepth(), expectedMatchedDepth);
 
         assertEq(bloomPool.tbyCollateral(0).assetAmount, 0);
-        assertEq(bloomPool.tbyCollateral(0).rwaAmount, rwaAmount);
+        assertEq(bloomPool.tbyCollateral(0).currentRwaAmount, rwaAmount);
 
         assertApproxEqRelDecimal(bloomPool.borrowerAmount(borrower, 0), expectedBorrowerAmount, 0.9999e18, 6);
         assertApproxEqRelDecimal(bloomPool.totalBorrowed(0), expectedBorrowerAmount, 0.9999e18, 6);
@@ -235,7 +235,8 @@ contract BloomPoolFuzzTest is BloomTestSetup {
         // Validate TBY State
         IBloomPool.TbyCollateral memory collateral = bloomPool.tbyCollateral(0);
         assertEq(collateral.assetAmount, amountNeeeded);
-        assertEq(collateral.rwaAmount, 0);
+        assertEq(collateral.currentRwaAmount, 0);
+        assertEq(collateral.startRwaAmount, rwaBalance);
 
         IBloomPool.TbyMaturity memory maturity = bloomPool.tbyMaturity(0);
         assertEq(maturity.start, startingTime);
@@ -318,7 +319,8 @@ contract BloomPoolFuzzTest is BloomTestSetup {
 
         IBloomPool.TbyCollateral memory collateral = bloomPool.tbyCollateral(0);
         assertEq(collateral.assetAmount, 0);
-        assertEq(collateral.rwaAmount, 0);
+        assertEq(collateral.currentRwaAmount, 0);
+        assertEq(collateral.startRwaAmount, rwaBalance);
     }
 
     function testFuzz_SwapOutAndRedeemWithPriceDrop(uint256 amount) public {
@@ -363,7 +365,7 @@ contract BloomPoolFuzzTest is BloomTestSetup {
         uint256 expectedLenderReturns = tbyTotalSupply.mulWad(tbyRate);
         uint256 expectedBorrowerReturns = collateral.assetAmount - expectedLenderReturns;
 
-        assertEq(collateral.rwaAmount, 0);
+        assertEq(collateral.currentRwaAmount, 0);
 
         assertApproxEqRelDecimal(bloomPool.lenderReturns(0), expectedLenderReturns, 0.0001e18, 6);
         assertApproxEqRelDecimal(bloomPool.borrowerReturns(0), expectedBorrowerReturns, 0.0001e18, 6);
@@ -393,7 +395,7 @@ contract BloomPoolFuzzTest is BloomTestSetup {
         uint256 rwaBalance = billToken.balanceOf(address(bloomPool));
 
         assertEq(bloomPool.tbyCollateral(id).assetAmount, 0);
-        assertEq(bloomPool.tbyCollateral(id).rwaAmount, rwaBalance);
+        assertEq(bloomPool.tbyCollateral(id).currentRwaAmount, rwaBalance);
 
         assertEq(bloomPool.tbyRwaPricing(id).startPrice, 110e18);
         assertEq(bloomPool.tbyRwaPricing(id).endPrice, 0);
@@ -410,7 +412,7 @@ contract BloomPoolFuzzTest is BloomTestSetup {
         assertEq(assetAmount2, stableBalance - assetAmount);
 
         assertEq(bloomPool.tbyCollateral(id).assetAmount, 0);
-        assertEq(bloomPool.tbyCollateral(id).rwaAmount, rwaBalance2);
+        assertEq(bloomPool.tbyCollateral(id).currentRwaAmount, rwaBalance2);
 
         uint256 totalValue = rwaBalance.mulWad(110e18) + (rwaBalance2 - rwaBalance).mulWad(110.8e18);
         uint256 normalizedPrice = totalValue.divWad(rwaBalance2);

--- a/test/Fuzz/BloomPoolFuzzTest.t.sol
+++ b/test/Fuzz/BloomPoolFuzzTest.t.sol
@@ -236,7 +236,7 @@ contract BloomPoolFuzzTest is BloomTestSetup {
         IBloomPool.TbyCollateral memory collateral = bloomPool.tbyCollateral(0);
         assertEq(collateral.assetAmount, amountNeeeded);
         assertEq(collateral.currentRwaAmount, 0);
-        assertEq(collateral.startRwaAmount, rwaBalance);
+        assertEq(collateral.originalRwaAmount, rwaBalance);
 
         IBloomPool.TbyMaturity memory maturity = bloomPool.tbyMaturity(0);
         assertEq(maturity.start, startingTime);
@@ -320,7 +320,7 @@ contract BloomPoolFuzzTest is BloomTestSetup {
         IBloomPool.TbyCollateral memory collateral = bloomPool.tbyCollateral(0);
         assertEq(collateral.assetAmount, 0);
         assertEq(collateral.currentRwaAmount, 0);
-        assertEq(collateral.startRwaAmount, rwaBalance);
+        assertEq(collateral.originalRwaAmount, rwaBalance);
     }
 
     function testFuzz_SwapOutAndRedeemWithPriceDrop(uint256 amount) public {

--- a/test/Unit/BloomUnitTest.t.sol
+++ b/test/Unit/BloomUnitTest.t.sol
@@ -171,7 +171,7 @@ contract BloomUnitTest is BloomTestSetup {
         assertEq(billToken.balanceOf(address(bloomPool)), expectedRwa);
 
         IBloomPool.TbyCollateral memory startCollateral = bloomPool.tbyCollateral(0);
-        assertEq(startCollateral.rwaAmount, expectedRwa);
+        assertEq(startCollateral.currentRwaAmount, expectedRwa);
         assertEq(startCollateral.assetAmount, 0);
 
         _skipAndUpdatePrice(180 days, 110e8, 2);
@@ -184,7 +184,7 @@ contract BloomUnitTest is BloomTestSetup {
         assertEq(billToken.balanceOf(marketMaker), expectedRwa);
 
         IBloomPool.TbyCollateral memory endCollateral = bloomPool.tbyCollateral(0);
-        assertEq(endCollateral.rwaAmount, 0);
+        assertEq(endCollateral.currentRwaAmount, 0);
         assertEq(endCollateral.assetAmount, totalStableCollateral);
         assertEq(bloomPool.isTbyRedeemable(0), true);
     }
@@ -357,7 +357,7 @@ contract BloomUnitTest is BloomTestSetup {
         asset_amount = _swapOutWithCustomMarketMaker(0, 500e6, marketMaker);
 
         _swapOutWithCustomMarketMaker(0, 500, marketMaker2);
-        assertEq(bloomPool.tbyCollateral(0).rwaAmount, 0);
+        assertEq(bloomPool.tbyCollateral(0).currentRwaAmount, 0);
         assertEq(bloomPool.isTbyRedeemable(0), true);
     }
 }


### PR DESCRIPTION
In order to protect against the `totalRwaCollateral` value from being inaccurate due to `rwaPrice.endPrice` updating downwards, it has been decided to store that value within the `TbyCollateral` struct instead of trying to manually calculate it during `swapOut`.

The `TbyCollateral` struct is now made up of 3 parameters,

- `assetAmount` the amount of underlying assets currently backed by the TBY.
- `startRwaAmount` the amount of RWA tokens that the TBY was backed by at the time all TBYs were minted.
- `currentRwaAmount` the amount of RWA tokens that are currently backed by the TBY.