### PR TITLE
Borrower DOS

### DIFF
--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -387,7 +387,7 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
 
             if (remainingAmount != 0) {
                 // If the match order is already closed by the borrower, skip it
-                if (matches[index].borrower == address(0)) {
+                if (matches[index].lCollateral == 0) {
                     matches.pop();
                     continue;
                 }

--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -396,7 +396,6 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
                     _calculateRemovalAmounts(remainingAmount, matches[index].lCollateral, matches[index].bCollateral);
                 uint256 amountToRemove = lenderFunds + borrowerFunds;
 
-                if (amountToRemove == 0) break;
                 remainingAmount -= amountToRemove;
 
                 _borrowerAmounts[matches[index].borrower][id] += borrowerFunds;

--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -386,6 +386,12 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
             uint256 index = i - 1;
 
             if (remainingAmount != 0) {
+                // If the match order is already closed by the borrower, skip it
+                if (matches[index].borrower == address(0)) {
+                    matches.pop();
+                    continue;
+                }
+
                 (uint256 lenderFunds, uint256 borrowerFunds) =
                     _calculateRemovalAmounts(remainingAmount, matches[index].lCollateral, matches[index].bCollateral);
                 uint256 amountToRemove = lenderFunds + borrowerFunds;

--- a/src/Orderbook.sol
+++ b/src/Orderbook.sol
@@ -123,8 +123,9 @@ abstract contract Orderbook is IOrderbook, PoolStorage {
             if (matches[i].borrower == msg.sender) {
                 lenderAmount = uint256(matches[i].lCollateral);
                 borrowerReturn = uint256(matches[i].bCollateral);
-                // Zero out the match order to preserve the array's order
-                matches[i] = MatchOrder({lCollateral: 0, bCollateral: 0, borrower: address(0)});
+                // Zero out the collateral amounts of the match order to preserve the array's order
+                matches[i].lCollateral = 0;
+                matches[i].bCollateral = 0;
                 // Decrement the matched depth and open move the lenders collateral to an open order.
                 _matchedDepth -= lenderAmount;
                 _openOrder(lender, lenderAmount);
@@ -243,8 +244,8 @@ abstract contract Orderbook is IOrderbook, PoolStorage {
         for (uint256 i = length; i != 0; --i) {
             uint256 index = i - 1;
 
-            // If the match order is already closed by the borrower, skip it
-            if (matches[index].borrower == address(0)) {
+            // If the match order is already closed, remove it from the array
+            if (matches[index].lCollateral == 0) {
                 matches.pop();
                 continue;
             }

--- a/test/Fuzz/BloomPoolFuzzTest.t.sol
+++ b/test/Fuzz/BloomPoolFuzzTest.t.sol
@@ -551,7 +551,7 @@ contract BloomPoolFuzzTest is BloomTestSetup {
         assertEq(bloomPool.amountOpen(alice), amount / 2);
         assertEq(bloomPool.amountMatched(alice), amount / 2);
         IOrderbook.MatchOrder memory borrower2Order = bloomPool.matchedOrder(alice, 1);
-        assertEq(borrower2Order.borrower, address(0));
+        assertEq(borrower2Order.borrower, borrower2);
         assertEq(borrower2Order.lCollateral, 0);
         assertEq(borrower2Order.bCollateral, 0);
 

--- a/test/Fuzz/BloomPoolFuzzTest.t.sol
+++ b/test/Fuzz/BloomPoolFuzzTest.t.sol
@@ -526,4 +526,44 @@ contract BloomPoolFuzzTest is BloomTestSetup {
         bloomPool.redeemBorrower(0);
         vm.stopPrank();
     }
+
+    function testFuzz_SwapOutWithTwoBorrowersAndOneCancels(uint256 amount) public {
+        amount = bound(amount, 1e6, 100_000_000e6);
+        vm.assume(amount % 2 == 0);
+
+        address borrower2 = makeAddr("borrower2");
+        bloomPool.whitelistBorrower(borrower2, true);
+
+        _createLendOrder(alice, amount);
+        lenders.push(alice);
+
+        uint256 totalCollateral = amount;
+        uint256 borrowAmount = _fillOrder(alice, amount / 2);
+        totalCollateral += borrowAmount;
+        totalCollateral += _fillOrderWithCustomBorrower(alice, amount / 2, borrower2);
+
+        // Borrower2 cancels order
+        vm.startPrank(borrower2);
+        bloomPool.killBorrowerMatch(alice);
+        vm.stopPrank();
+
+        // Validate that the order is cancelled
+        assertEq(bloomPool.amountOpen(alice), amount / 2);
+        assertEq(bloomPool.amountMatched(alice), amount / 2);
+        IOrderbook.MatchOrder memory borrower2Order = bloomPool.matchedOrder(alice, 1);
+        assertEq(borrower2Order.borrower, address(0));
+        assertEq(borrower2Order.lCollateral, 0);
+        assertEq(borrower2Order.bCollateral, 0);
+
+        _swapIn(totalCollateral);
+        _skipAndUpdatePrice(180 days, 115e8, 2);
+
+        assertEq(tby.balanceOf(alice, 0), amount / 2);
+
+        // Check borrower data
+        uint256 totalBorrowed = bloomPool.totalBorrowed(0);
+        assertEq(totalBorrowed, borrowAmount);
+        assertEq(bloomPool.borrowerAmount(borrower, 0), borrowAmount);
+        assertEq(bloomPool.borrowerAmount(borrower2, 0), 0);
+    }
 }

--- a/test/Unit/OrderbookUnitTest.t.sol
+++ b/test/Unit/OrderbookUnitTest.t.sol
@@ -94,7 +94,7 @@ contract OrderbookUnitTest is BloomTestSetup {
         assertEq(bloomPool.openDepth(), 100e6);
         assertEq(postCancelMatchedOrder.bCollateral, 0);
         assertEq(postCancelMatchedOrder.lCollateral, 0);
-        assertEq(postCancelMatchedOrder.borrower, address(0));
+        assertEq(postCancelMatchedOrder.borrower, borrower);
 
         // Validate balances
         assertEq(stable.balanceOf(borrower), borrowerPreBalance + matchedOrder.bCollateral);


### PR DESCRIPTION
There is a possibility if multiple borrowers exist and one borrower cancels their match, that a lender wont be able to have their TBY minted during `swapIn` due to a DOS caused by an empty `MatchOrder` in order to negate this issue, we must check if a `MatchOrder` is empty and pop it if `matches[index].lCollateral == 0`. 

Originally we popped the match in the orderbook if `matches[index].borrower == address(0)`, but this allows a malicious borrower to DOS a lender by creating a large amount of empty orders. Within the orderbook we also apply this change.