### PR TITLE
Borrower Overcommit

### DIFF
--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -408,6 +408,7 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
                     matches.pop();
                 } else {
                     matches[index].lCollateral -= uint128(lenderFunds);
+                    matches[index].bCollateral -= uint128(borrowerFunds);
                 }
             } else {
                 break;


### PR DESCRIPTION
Within `_convertMatchOrders`, only lenders collateral is decremented on conversion. This causes issue in the event of a partial match in which the borrowers funds will be counted multiple times thus overvaluing their contribution. To fix this we simply need to decrement `matches[index].bCollateral` when we decrement `matches[index].lCollateral`.