### PR TITLE
Oracle answerInRound

### DIFF
--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -356,13 +356,11 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
     /// @notice Returns the current price of the RWA token.
     function _rwaPrice() private view returns (uint256) {
         RwaPriceFeed memory priceFeed = _rwaPriceFeed;
-        (uint80 roundId, int256 answer,, uint256 updatedAt, uint80 answeredInRound) =
-            AggregatorV3Interface(priceFeed.priceFeed).latestRoundData();
+        (, int256 answer,, uint256 updatedAt,) = AggregatorV3Interface(priceFeed.priceFeed).latestRoundData();
 
         // Validate the latest round data from the price feed.
         require(answer > 0, Errors.InvalidPriceFeed());
         require(updatedAt >= block.timestamp - priceFeed.updateInterval, Errors.OutOfDate());
-        require(answeredInRound >= roundId, Errors.OutOfDate());
 
         uint256 scaler = 10 ** (18 - priceFeed.decimals);
         return uint256(answer) * scaler;
@@ -427,13 +425,11 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
     /// @notice Logic to set the price feed for the RWA token.
     function _setPriceFeed(address rwaPriceFeed_, uint64 priceFeedUpdateInterval_) internal {
         require(priceFeedUpdateInterval_ != 0, Errors.ZeroAmount());
-        (uint80 roundId, int256 answer,, uint256 updatedAt, uint80 answeredInRound) =
-            AggregatorV3Interface(rwaPriceFeed_).latestRoundData();
+        (, int256 answer,, uint256 updatedAt,) = AggregatorV3Interface(rwaPriceFeed_).latestRoundData();
 
         // Validate the latest round data from the price feed.
         require(answer > 0, Errors.InvalidPriceFeed());
         require(updatedAt >= block.timestamp - priceFeedUpdateInterval_, Errors.OutOfDate());
-        require(answeredInRound >= roundId, Errors.OutOfDate());
 
         // Set the price feed for the RWA token.
         _rwaPriceFeed = RwaPriceFeed({

--- a/test/Unit/BloomUnitTest.t.sol
+++ b/test/Unit/BloomUnitTest.t.sol
@@ -68,11 +68,6 @@ contract BloomUnitTest is BloomTestSetup {
         priceFeed.setLatestRoundData(0, 1, 0, 0, 0);
         vm.expectRevert(Errors.OutOfDate.selector);
         bloomPool.setPriceFeed(address(priceFeed), 1 days);
-
-        // Revert if feed hasnt has the wrong round id
-        priceFeed.setLatestRoundData(1, 1, 0, 0, 0);
-        vm.expectRevert(Errors.OutOfDate.selector);
-        bloomPool.setPriceFeed(address(priceFeed), 1 days);
     }
 
     function testSetMaturitySuccess() public {


### PR DESCRIPTION
Per Chainlink's [documentation](https://docs.chain.link/data-feeds/api-reference#latestrounddata-1), they have deprecated `answerInRound` from their Oracles. In order to reduce unnecessary checks from the codebase this will be removed.