### PR TITLE
Spread Cache

### DIFF
--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -246,7 +246,7 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
                     (collateral.currentRwaAmount - rwaAmount).mulWad(currentPrice) / _assetScalingFactor;
                 uint256 totalCollateral = accumulatedCollateral + remainingAmount;
                 uint256 newRate = totalCollateral.divWad(_tby.totalSupply(id));
-                uint256 adjustedRate = _takeSpread(newRate);
+                uint256 adjustedRate = _takeSpread(newRate, rwaPrice.spread);
                 rwaPrice.endPrice = uint128(adjustedRate.mulWad(rwaPrice.startPrice));
             }
         }
@@ -328,6 +328,7 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
         uint256 startPrice = rwaPrice.startPrice;
         if (startPrice == 0) {
             rwaPrice.startPrice = uint128(currentPrice);
+            rwaPrice.spread = uint128(_spread);
         } else if (startPrice != currentPrice) {
             rwaPrice.startPrice = uint128(_normalizePrice(startPrice, currentPrice, rwaAmount, existingCollateral));
         }
@@ -464,11 +465,16 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
         borrowerFunds = remainingAmount - lenderFunds;
     }
 
-    /// @notice Takes removes the borrower's interest earned off the yield of the RWA token in order to calculate the TBY rate.
-    function _takeSpread(uint256 rate) internal view returns (uint256) {
+    /**
+     * @notice Takes the spread for the TBY and removes the borrower's interest earned off the yield of the RWA token in order to calculate the TBY rate.
+     * @param rate The full rate of the TBY.
+     * @param tbySpread The cached spread for the TBY.
+     * @return The adjusted rate for the TBY that the lender will earn.
+     */
+    function _takeSpread(uint256 rate, uint128 tbySpread) internal pure returns (uint256) {
         if (rate > Math.WAD) {
             uint256 yield = rate - Math.WAD;
-            return Math.WAD + yield.mulWad(_spread);
+            return Math.WAD + yield.mulWad(tbySpread);
         }
         return rate;
     }
@@ -493,7 +499,7 @@ contract BloomPool is IBloomPool, Orderbook, ReentrancyGuard {
         // If the TBY has matured, and is eligible for redemption, calculate the rate based on the end price.
         uint256 price = rwaPrice.endPrice != 0 ? rwaPrice.endPrice : _rwaPrice();
         uint256 rate = (uint256(price).divWad(uint256(rwaPrice.startPrice)));
-        return _takeSpread(rate);
+        return _takeSpread(rate, rwaPrice.spread);
     }
 
     /// @inheritdoc IBloomPool

--- a/src/interfaces/IBloomPool.sol
+++ b/src/interfaces/IBloomPool.sol
@@ -47,10 +47,12 @@ interface IBloomPool is IOrderbook, IPoolStorage {
      * @notice Struct to store the price range for RWA assets at the time of lTBY start and end times.
      * @param startPrice The starting price of the RWA at the time of the market maker swap.
      * @param endPrice  The ending price of the RWA at the time of the market maker swap.
+     * @param spread The spread for the TBY.
      */
     struct RwaPrice {
         uint128 startPrice;
         uint128 endPrice;
+        uint128 spread;
     }
 
     /**


### PR DESCRIPTION
Previously the spread updates would affect previously minted TBYs. While this isnt an issue with `BloomPool`s directly, it has potential negative effects on downstream integrations. In order to make `BloomPool`s more composable, this PR cache's the spread during `swapIn` and utilizes that value over the entirety of a given `tbyId`'s lifecycle, allowing different `tbyId`s to have different spreads.